### PR TITLE
Adding name of United Nations flag

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -244,7 +244,7 @@ en:
         ua: Ukraine
         ug: Uganda
         um: "US Minor Outlying Islands"
-        un: undefined
+        un: "United Nations"
         us: "United States"
         us-at: undefined
         uy: Uruguay


### PR DESCRIPTION
The UN flag's name is currently "undefined"; adding that value to the list.