### PR TITLE
Fix Norway flag

### DIFF
--- a/config/flags.yml
+++ b/config/flags.yml
@@ -172,7 +172,7 @@ nf: nf.png
 ng: ng.png
 ni: ni.png
 nl: nl.png
-no: no.png
+'no': no.png
 np: np.png
 nr: nr.png
 nu: nu.png

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -74,7 +74,6 @@ en:
         es: Spain
         et: Ethiopia
         eu: Europe
-        false: Norway
         fi: Finland
         fj: Fiji
         fk: "Falkland Islands (Malvinas)"
@@ -177,7 +176,7 @@ en:
         ng: Nigeria
         ni: Nicaragua
         nl: Netherlands         
-        no: Norway
+        'no': Norway
         none: "No flag"
         np: Nepal
         nr: Nauru


### PR DESCRIPTION
Yaml has some [reserved keywords](https://makandracards.com/makandra/24809-yaml-keys-like-yes-or-no-evaluate-to-true-and-false) and 'no' (Norway's country code) on a key was being interpreted as false. Escaping seems to do it. Fixes #5 and #7 (duplicate).