### PR TITLE
Add required pluginId

### DIFF
--- a/assets/javascripts/discourse/initializers/nationalflags.js.es6
+++ b/assets/javascripts/discourse/initializers/nationalflags.js.es6
@@ -33,6 +33,7 @@ function initializeNationalFlags(api, siteSettings) {
   });
 
   api.modifyClass('route:preferences', {
+    pluginId: 'discourse-nationalflags',
     afterModel(model) {
       return ajax('/natflags/flags').then(natflags => {
         let localised_flags = [];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1707290/194950847-c1af24e8-3634-48a0-b690-21160511f965.png)

[PLUGIN discourse-nationalflags] To prevent errors in tests, add a `pluginId` key to your `modifyClass` call. This will ensure the modification is only applied once.