### PR TITLE
FIX: Remove register_asset call for `.hbs` files

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -62,8 +62,6 @@ after_initialize do
   end
 end
 
-register_asset "javascripts/discourse/templates/connectors/user-custom-preferences/user-nationalflags-preferences.hbs"
-register_asset "javascripts/discourse/templates/connectors/user-profile-primary/show-user-card.hbs"
 register_asset "stylesheets/nationalflags.scss"
 
 DiscourseEvent.on(:custom_wizard_ready) do


### PR DESCRIPTION
Files in the `assets/javascripts` directory are automatically compiled, so this was introducing a duplicate. In the latest version of Discourse this also triggers a build error